### PR TITLE
Candidate fix  for TRLST-53 and TRLST-54

### DIFF
--- a/trade_remedies_caseworker/cases/views.py
+++ b/trade_remedies_caseworker/cases/views.py
@@ -174,6 +174,7 @@ class CaseBaseView(
                 "Case": {
                     "id": 0,
                     "name": 0,
+                    "case_email": "investigations@traderemedies.gov.uk",
                     "initiated_at": 0,
                     "decision_to_initiate,name": 0,
                     "reference": 0,
@@ -321,6 +322,8 @@ class CaseAdminView(CaseBaseView):
             update_spec["stage_id"] = request.POST.get("stage_id")
         elif action == "set_name":
             update_spec["name"] = request.POST.get("name")
+        elif action == "set_case_email":
+            update_spec["case_email"] = request.POST.get("case_email")
         elif action == "set_case_type":
             update_spec["stage_id"] = ""
             update_spec["type_id"] = request.POST.get("type_id")
@@ -2247,6 +2250,7 @@ class CaseFormView(LoginRequiredMixin, TemplateView, TradeRemediesAPIClientMixin
         non_required_fields = [
             "submission_status_id",
             "case_name",
+            "case_email",
             "organisation_name",
             "organisation_id",
             # 'organisation_address', 'organisation_post_code', 'companies_house_id',
@@ -2362,9 +2366,15 @@ class InviteContactView(CaseBaseView):
             "deadline": parse_api_datetime(
                 get(self.case, "registration_deadline"), settings.FRIENDLY_DATE_FORMAT
             ),
-            "footer": self._client.get_system_parameters("NOTIFY_BLOCK_FOOTER")["value"],
+            "footer": self._client.get_system_parameters("NOTIFY_BLOCK_FOOTER_CASE_SPECIFIC")[
+                "value"
+            ].format(
+                self.case["case_email"]
+                or self._client.get_system_parameters("TRADE_REMEDIES_EMAIL")["value"]
+            ),
             "guidance_url": self._client.get_system_parameters("LINK_HELP_BOX_GUIDANCE")["value"],
-            "email": self._client.get_system_parameters("TRADE_REMEDIES_EMAIL")["value"],
+            "email": self.case["case_email"]
+            or self._client.get_system_parameters("TRADE_REMEDIES_EMAIL")["value"],
             "login_url": f"{settings.PUBLIC_BASE_URL}",
         }
         context = {

--- a/trade_remedies_caseworker/templates/cases/admin.html
+++ b/trade_remedies_caseworker/templates/cases/admin.html
@@ -97,7 +97,19 @@
         </button>
     </form>
 
-    <h3 class="heading-medium">Archived Case</h3>
+    <h3 class="heading-medium">Case email</h3>
+    <form action="/case/{{case.id}}/admin/" method="post">
+      {% csrf_token %}
+      <p>
+        The case email address is <em>{{case.case_email}}</em>.
+      </p>
+      <input type="text" class="form-control" name="case_email" value="{{case.case_email}}"/>
+      <button type="submit" class="button" name="action" value="set_case_email">
+        Update case email
+      </button>
+    </form>
+
+  <h3 class="heading-medium">Archived Case</h3>
     <form action="/case/{{case.id}}/admin/" method="post">
         {% csrf_token %}
         <p>

--- a/trade_remedies_caseworker/templates/cases/case_form.html
+++ b/trade_remedies_caseworker/templates/cases/case_form.html
@@ -49,6 +49,7 @@
                 </select>
             </div>
             {% text_element id='case_name' label='Case name' errors=errors value=case_name hint='If you don\'t enter a name here, one will be generated automatically'%}
+            {% text_element id='case_email' label='Case email' errors=errors value=case_email hint='(if left blank, the default email address <investigations@traderemedies.gov.uk> will be used.)'%}
             <div class="form-group">
                 <h2 class="heading-medium">Applicant (TRA)</h2>
             </div>


### PR DESCRIPTION
For review.
Part of a candidate fix for TRLST-53 and TRLST-54. See also corresponding PR / branch in trade-remedies-api.
Apart from further testing reviews and revisions, the outstanding work is to identify all the places where the case-specific email is used and make sure it does indeed appear.
Please note that the trade-remedies-api component of the fix makes a change to the django database schema, which needs to be updated accordingly - (i.e. migration etc.)