### PR TITLE
Feature/trlst 174 invite mechanics

### DIFF
--- a/trade_remedies_caseworker/templates/widgets/contact_block.html
+++ b/trade_remedies_caseworker/templates/widgets/contact_block.html
@@ -67,9 +67,27 @@
 
 			{% elif pre_release_invitations and not organisation.users %}
 				{% if not contact.cases|_get:case_id or not contact.has_user %}
-					<button type="button" class="button modal-form button-blue compact margin-top-1" data-event-update="party-updated" data-url="/case/{{case.id}}/invite/{{contact.id}}/as/{{case_role_id}}/for/{{organisation.id}}/">Invite <span class="visually-hidden"> {{contact.name}}</span>to case</button>
-				{% endif %}
-			{% endif %}
+                    {% if contact.is_third_party %}
+                        <button type="button"
+                                class="button modal-form button-blue compact margin-top-1"
+                                data-event-update="party-updated"
+                                data-url="/case/{{case.id}}/submission/{{contact.submission_id}}/invite/{{contact.id}}/notify/">
+                            Invite
+                            <span class="visually-hidden">{{contact.name}}
+                            </span>to case
+                        </button>
+                    {% else %}
+                        <button type="button"
+                                class="button modal-form button-blue compact margin-top-1"
+                                data-event-update="party-updated"
+                                data-url="/case/{{case.id}}/invite/{{contact.id}}/as/{{case_role_id}}/for/{{organisation.id}}/">
+                            Invite
+                            <span class="visually-hidden">{{contact.name}}
+                            </span>to case
+                        </button>
+                    {% endif %}
+                {% endif %}
+            {% endif %}
 
 			{% if not hide_primary and case_id and contact.has_user %}
 				{# If we have a case id, we can set the primary contact #}

--- a/trade_remedies_caseworker/templates/widgets/contact_list.html
+++ b/trade_remedies_caseworker/templates/widgets/contact_list.html
@@ -17,6 +17,9 @@
 		{% if contact.primary %}
 			{% set 'primary_count' store.primary_count|_plus:'1' %}
 		{% endif %}
+        {% if third_party_contacts|length > 0 %}
+            {% set 'has_out_case' True %}
+        {% endif %}
 	{% endfor %}
 	{% if store.has_in_case %}
 		<div class="section-heading">Contacts involved in this case</div>


### PR DESCRIPTION
# Implement [TRLST 174](https://uktrade.atlassian.net/browse/TRLST-174) Third Party Invite mechanics

This PR completes the implementation of the Caseworker Portal 3rd Party Invite journey.

- Modified unused and incomplete SubmissionInviteNotifyView to process 3P submissions correctly.
- Updated OrganisationDetailsView's 3P contact data to include submission id.
- Routed save+continue if a deficiency notice is being built.
- Update contact block so 3P invite button correctly routed to SubmissionInviteNotifyView.