### PR TITLE
fix: don't use redundant xl extension

### DIFF
--- a/trade_remedies_caseworker/cases/views.py
+++ b/trade_remedies_caseworker/cases/views.py
@@ -2167,7 +2167,7 @@ class CaseAuditExport(LoginRequiredMixin, View, TradeRemediesAPIClientMixin):
     def get(self, request, case_id, *args, **kwargs):
         file = self.client(request.user).get_audit_export(case_id)
         response = HttpResponse(file, content_type="application/vnd.ms-excel")
-        response["Content-Disposition"] = "attachment; filename=trade_remedies_export.xls"
+        response["Content-Disposition"] = "attachment; filename=trade_remedies_export.xlsx"
         return response
 
 

--- a/trade_remedies_caseworker/core/views.py
+++ b/trade_remedies_caseworker/core/views.py
@@ -295,5 +295,5 @@ class FeedbackFormExportView(
     def get(self, request, form_id=None):
         file = self.client(request.user).export_feedback(form_id)
         response = HttpResponse(file, content_type="application/vnd.ms-excel")
-        response["Content-Disposition"] = "attachment; filename=trade_remedies_export.xls"
+        response["Content-Disposition"] = "attachment; filename=trade_remedies_export.xlsx"
         return response


### PR DESCRIPTION
The 'xls' file extension causes a browser to prompt a warning because the file format is unknown. Fixed to use xlsx instead.