### PR TITLE
fix: http error page templates

### DIFF
--- a/trade_remedies_caseworker/templates/400.html
+++ b/trade_remedies_caseworker/templates/400.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+{% load format_date %}
+
+{% block header_row %}
+    <div class="grid-row">
+        <div class="column-two-thirds">
+            <h1 class="heading-large"><span class="heading-secondary">HTTP 400</span>
+                <i class="icon32 icon-amber-warning"><span
+                        class="visually-hidden">Alert</span></i>
+                Bad Request
+            </h1>
+            <p>
+                Oops, the server was unable to process the request. Here are some
+                things you can try:
+            </p>
+            <ul class="list list-bullet double-spaced">
+                <li>Check your session has not expired (try to re-login).</li>
+                <li>Check the URL of the page you are attempting to access is correct.
+                    For example, are you using a bookmark or copy-pasted url?
+                </li>
+                <li>Were you uploading a file? Check its size, it may be too big.</li>
+                <li>Try clearing your browser cache and cookies.</li>
+            </ul>
+            <p><em>If problems persist, please contact support.</em></p>
+        </div>
+    </div>
+{% endblock %}

--- a/trade_remedies_caseworker/templates/400.html
+++ b/trade_remedies_caseworker/templates/400.html
@@ -5,8 +5,9 @@
     <div class="grid-row">
         <div class="column-two-thirds">
             <h1 class="heading-large"><span class="heading-secondary">HTTP 400</span>
-                <i class="icon32 icon-amber-warning"><span
-                        class="visually-hidden">Alert</span></i>
+                <i class="icon32 icon-amber-warning">
+                    <span class="visually-hidden">Alert</span>
+                </i>
                 Bad Request
             </h1>
             <p>

--- a/trade_remedies_caseworker/templates/403.html
+++ b/trade_remedies_caseworker/templates/403.html
@@ -4,19 +4,21 @@
 {% block header_row %}
     <div class="grid-row">
         <div class="column-two-thirds">
-            <h1 class="heading-large"><span class="heading-secondary">HTTP 404</span>
+            <h1 class="heading-large"><span class="heading-secondary">HTTP 403</span>
                 <i class="icon32 icon-amber-warning"><span
                         class="visually-hidden">Alert</span></i>
-                Not Found
+                Forbidden
             </h1>
             <p>
-                Oops, the page you requested could not be found. Here are some things
-                you can try:
+                Oops, you do not have permission to view the page you requested.
+                Here are some things you can try:
             </p>
             <ul class="list list-bullet double-spaced">
-                <li>If you entered a web address, please check that it was correct.</li>
-                <li>Use your browser's back button and check the link that you clicked.</li>
-                <li>If you clicked a link that brought you to this page, please let us know.</li>
+                <li>Make sure you are logged in.</li>
+                <li>Make sure you are requesting a page you have permission to see.</li>
+                <li>Ask your administrator if your permissions are correctly set.</li>
+                <li>Make sure cookies are enabled for this site.</li>
+                <li>Try clearing your browser cache and cookies.</li>
                 <li>Return to the <a class="link" href="/">home page</a> and start
                     again</li>
             </ul>

--- a/trade_remedies_caseworker/templates/403.html
+++ b/trade_remedies_caseworker/templates/403.html
@@ -5,8 +5,9 @@
     <div class="grid-row">
         <div class="column-two-thirds">
             <h1 class="heading-large"><span class="heading-secondary">HTTP 403</span>
-                <i class="icon32 icon-amber-warning"><span
-                        class="visually-hidden">Alert</span></i>
+                <i class="icon32 icon-amber-warning">
+                    <span class="visually-hidden">Alert</span>
+                </i>
                 Forbidden
             </h1>
             <p>

--- a/trade_remedies_caseworker/templates/404.html
+++ b/trade_remedies_caseworker/templates/404.html
@@ -5,8 +5,9 @@
     <div class="grid-row">
         <div class="column-two-thirds">
             <h1 class="heading-large"><span class="heading-secondary">HTTP 404</span>
-                <i class="icon32 icon-amber-warning"><span
-                        class="visually-hidden">Alert</span></i>
+                <i class="icon32 icon-amber-warning">
+                    <span class="visually-hidden">Alert</span>
+                </i>
                 Not Found
             </h1>
             <p>

--- a/trade_remedies_caseworker/templates/500.html
+++ b/trade_remedies_caseworker/templates/500.html
@@ -4,8 +4,9 @@
     <div class="grid-row">
         <div class="column-two-thirds">
             <h1 class="heading-large"><span class="heading-secondary">HTTP 500</span>
-                <i class="icon32 icon-alert"><span
-                        class="visually-hidden">Alert</span></i>
+                <i class="icon32 icon-alert">
+                    <span class="visually-hidden">Alert</span>
+                </i>
                 Server Error
             </h1>
             <p>

--- a/trade_remedies_caseworker/templates/500.html
+++ b/trade_remedies_caseworker/templates/500.html
@@ -1,20 +1,26 @@
 {% extends "base.html" %}
-{% load format_date %}
 
-{% block inner_content %}
-<div class="grid-row">
-  <div class="column-two-thirds">
-      
-    <h1 class="heading-large"><span class="heading-secondary">Error 500</span>
-      <i class="icon32 icon-amber-warning"><span class="visually-hidden">Alert</span></i>Server error
-    </h1>
-      <p>Something went wrong on our server. Here are some things you can try:</p>
-      <ul class="list list-bullet double-spaced">
-        <li>If you entered a web address, please check that it was correct.</li>
-        <li>Use your browser's back button and check the link that you clicked.</li>
-        <li>If you clicked a link that brought you to this page, please let us know.</li>
-        <li>Return to the <a class="link" href="\">home page</a> and start again</li>
-      </ul>
-  </div>
-</div>
+{% block header_row %}
+    <div class="grid-row">
+        <div class="column-two-thirds">
+            <h1 class="heading-large"><span class="heading-secondary">HTTP 500</span>
+                <i class="icon32 icon-alert"><span
+                        class="visually-hidden">Alert</span></i>
+                Server Error
+            </h1>
+            <p>
+                Oops, something has gone wrong. This might be an intermittent
+                issue that will be automatically remediated. In the meantime
+                here are some things you can try:
+            </p>
+            <ul class="list list-bullet double-spaced">
+                <li>If you entered a web address, please check that it was correct.</li>
+                <li>Use your browser's back button and check the link that you clicked.</li>
+                <li>If you clicked a link that brought you to this page, please let us know.</li>
+                <li>Return to the <a class="link" href="/">home page</a> and start
+                    again</li>
+            </ul>
+            <p><em>If problems persist, please contact support.</em></p>
+        </div>
+    </div>
 {% endblock %}


### PR DESCRIPTION
The existing 404 and 500 templates did not work. Also added 400 and 403 for good measure.