### PR TITLE
fix: TRLST-372 fix user create.

### DIFF
--- a/trade_remedies_caseworker/templates/settings/user.html
+++ b/trade_remedies_caseworker/templates/settings/user.html
@@ -28,7 +28,11 @@
                 {% text_element id='password_confirm' label='Confirm password' errors=errors value=edit_user.password_confirm password=True  readonly=read_only %}
                 {% if not edit_user.tra %}
 	                <label for="organisation" class="form-label">Organisation</label>
-	                <a href="/organisation/{{edit_user.organisations.0.id}}/" >{{edit_user.organisations.0.name}}</a>
+                    {% if edit_user.organisations %}
+	                    <a href="/organisation/{{edit_user.organisations.0.id}}/" >{{edit_user.organisations.0.name}}</a>
+                    {% else %}
+                        Not set
+                    {% endif %}
 	            {% endif %}
             </div>
             <div class="column-one-half">

--- a/trade_remedies_caseworker/users/views.py
+++ b/trade_remedies_caseworker/users/views.py
@@ -199,7 +199,9 @@ class UserView(UserBaseTemplateView):
         else:
             user["country_code"] = user.get("country_code", "GB")
             user["timezone"] = user.get("timezone", "Europe/London")
-        form_action = form_actions[request.resolver_match.url_name]
+        action = request.resolver_match.url_name
+        user["tra"] = True if action.endswith("investigator") else False
+        form_action = form_actions[action]
         return render(
             request,
             self.template_name,
@@ -258,6 +260,8 @@ class UserView(UserBaseTemplateView):
         user["groups"] = request.POST.getlist(
             "roles"
         )  # translation needed as the create write key doesn't match the update
+        action = request.resolver_match.url_name
+        user["tra"] = True if action.endswith("investigator") else False
         errors = validate_required_fields(request, required_fields) or {}
         if password_errors := self.validate_password(request, user):
             errors.update(password_errors)


### PR DESCRIPTION
Fixes issue with caseworker user creation. The TRA flag indication type of user (cw/public) was not being set and causing user creation to fail. This change ensures the type of user being created is detected and applied.