### PR TITLE
Fix - TSS-922 - Unable to change submission status

### DIFF
--- a/trade_remedies_caseworker/templates/cases/submissions/review.html
+++ b/trade_remedies_caseworker/templates/cases/submissions/review.html
@@ -62,7 +62,7 @@
             {% set 'deficiency_notice' submission.deficiency_notice_params.review_result|_equals:'deficient' %}
             {% set 'building_deficiency_notice' deficiency_notice|_and:received_state %}
             {% set 'not_reviewed' submission.deficiency_notice_params.review_result|_not %}
-            {% set 'reviewing' not_reviewed|_and:received_state %}
+            {% set 'reviewing' not_reviewed %}
             {% set 'reviewed' not_reviewed|_not %}
             {% set 'not_published' submission.issued_at|_not %}
             {% set 'publishing' submission.deficiency_notice_params.publish|_and:not_published %}


### PR DESCRIPTION
Assumes we are reviewing the document when we have not reviewed it before, allowing for deficiency/sufficiency status changes